### PR TITLE
move github authentication details to .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,14 @@ This class contains no public methods of interest. This class should be added to
 
 ##### Real Examples
 
-Here you can see an example of just how simple this package is to use. Out of the box, the default adapter is `main`. After you enter your authentication details in the config file, it will just work:
+Here you can see an example of just how simple this package is to use. Out of the box, the default adapter is `main`. After you enter your authentication details in .env file:
+
+```
+// using the default connection
+GITHUB_TOKEN=your-token
+```
+
+it will just work:
 
 ```php
 use GrahamCampbell\GitHub\Facades\GitHub;

--- a/config/github.php
+++ b/config/github.php
@@ -39,7 +39,7 @@ return [
     'connections' => [
 
         'main' => [
-            'token'      => 'your-token',
+            'token'      => env('GITHUB_TOKEN', 'your-token'),
             'method'     => 'token',
             // 'backoff'    => false,
             // 'cache'      => false,
@@ -48,8 +48,8 @@ return [
         ],
 
         'alternative' => [
-            'clientId'     => 'your-client-id',
-            'clientSecret' => 'your-client-secret',
+            'clientId'     => env('GITHUB_CLIENT_ID', 'your-client-id'),
+            'clientSecret' => env('GITHUB_CLIENT_SECRET', 'your-client-secret'),
             'method'       => 'application',
             // 'backoff'      => false,
             // 'cache'        => false,
@@ -58,8 +58,8 @@ return [
         ],
 
         'other' => [
-            'username'   => 'your-username',
-            'password'   => 'your-password',
+            'username'   => env('GITHUB_USERNAME', 'your-username'),
+            'password'   => env('GITHUB_PASSWORD', 'your-password'),
             'method'     => 'password',
             // 'backoff'    => false,
             // 'cache'      => false,


### PR DESCRIPTION
Since GitHub will revoke token when an access token is committed to a public GitHub repository.