### PR TITLE
Also require Guzzle 6 adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Either [PHP](https://php.net) 5.5+ or [HHVM](http://hhvm.com) 3.6+ are required.
 To get the latest version of Laravel GitHub, simply require the project using [Composer](https://getcomposer.org):
 
 ```bash
-$ composer require graham-campbell/github
+$ composer require graham-campbell/github php-http/guzzle6-adapter
 ```
 
 Instead, you may of course manually update your require block and run `composer update` if you so choose:
@@ -30,7 +30,8 @@ Instead, you may of course manually update your require block and run `composer 
 ```json
 {
     "require": {
-        "graham-campbell/github": "^5.0"
+        "graham-campbell/github": "^5.0",
+        "php-http/guzzle6-adapter": "^1.1"
     }
 }
 ```


### PR DESCRIPTION
When I tried the current install instructions I got this message from Composer:

```
 ~/Sites/qa  composer require graham-campbell/github
Using version ^5.0 for graham-campbell/github
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - knplabs/github-api 2.0.1 requires php-http/client-implementation ^1.0 -> no matching package found.
    - knplabs/github-api 2.0.0 requires php-http/client-implementation ^1.0 -> no matching package found.
    - graham-campbell/github v5.0.0 requires knplabs/github-api ^2.0 -> satisfiable by knplabs/github-api[2.0.0, 2.0.1].
    - Installation request for graham-campbell/github ^5.0 -> satisfiable by graham-campbell/github[v5.0.0].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.

Installation failed, reverting ./composer.json to its original content.
```

Turns out that the https://github.com/KnpLabs/php-github-api repo also requires the `php-http/guzzle6-adapter` package in its install instructions. While I know that not everyone uses the specific version of Guzzle 6, I think it's best to include it in the install instructions like they do so people can install the package at least.