### PR TITLE
update knplabs package name, github-api to php-github-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.*",
         "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*",
         "graham-campbell/manager": "^2.3",
-        "knplabs/github-api": "^2.0"
+        "knplabs/php-github-api": "^2.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.1",


### PR DESCRIPTION
Seems like this package changed it's name. Updating only name, and not the version.