### PR TITLE
Add no authentication connection example to config/github.php

### DIFF
--- a/config/github.php
+++ b/config/github.php
@@ -78,6 +78,10 @@ return [
             // 'enterprise' => false,
         ],
 
+        'none' => [
+            'method' => 'none',
+        ],
+
     ],
 
 ];


### PR DESCRIPTION
Hi!

I am beginner so maybe this is obvious to a lot of people but with this commit every user who set the default connection to `none` it will automagically call the GitHub API without authentication.