### PR TITLE
Update Application Authenticator Auth Method

### DIFF
--- a/src/Authenticators/ApplicationAuthenticator.php
+++ b/src/Authenticators/ApplicationAuthenticator.php
@@ -42,7 +42,7 @@ class ApplicationAuthenticator extends AbstractAuthenticator
             throw new InvalidArgumentException('The application authenticator requires a client id and secret.');
         }
 
-        $this->client->authenticate($config['clientId'], $config['clientSecret'], Client::AUTH_URL_CLIENT_ID);
+        $this->client->authenticate($config['clientId'], $config['clientSecret'], Client::AUTH_HTTP_PASSWORD);
 
         return $this->client;
     }

--- a/tests/Authenticators/ApplicationAuthenticatorTest.php
+++ b/tests/Authenticators/ApplicationAuthenticatorTest.php
@@ -32,7 +32,7 @@ class ApplicationAuthenticatorTest extends AbstractTestCase
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('authenticate')->once()
-            ->with('your-client-id', 'your-client-secret', 'url_client_id');
+            ->with('your-client-id', 'your-client-secret', 'http_password');
 
         $return = $authenticator->with($client)->authenticate([
             'clientId'     => 'your-client-id',
@@ -49,7 +49,7 @@ class ApplicationAuthenticatorTest extends AbstractTestCase
 
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('authenticate')->once()
-            ->with('your-client-id', 'your-client-secret', 'url_client_id');
+            ->with('your-client-id', 'your-client-secret', 'http_password');
 
         $return = $authenticator->with($client)->authenticate([
             'clientId'     => 'your-client-id',


### PR DESCRIPTION
This pull request changes the `auth method` within the `client->authenticates()` call from `Client::AUTH_URL_CLIENT_ID` to `Client::AUTH_HTTP_PASSWORD` due to GitHub actively deprecating the use of query parameters to authenticate. Two tests were also updated.

---

Closes #103.