### PR TITLE
L8 compatibility in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Laravel GitHub requires [PHP](https://php.net) 7.2-7.4. This particular version 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org). You will need to install any package that "provides" `php-http/client-implementation`. Most users will want:
 
 ```bash
-$ composer require graham-campbell/github:^9.5 php-http/guzzle6-adapter:^2.0
+$ composer require graham-campbell/github:^9.5 php-http/guzzle7-adapter:^0.1
 ```
 
 If you'd like to use the private key authenticator, then you will also need to install `lcobucci/jwt`:


### PR DESCRIPTION
Hi Graham,

Just tried installing this on latest Laravel. `laravel/laravel` is now set to 7+ for guzzlehttp/guzzle (see https://github.com/laravel/laravel/commit/48b7ba938e71c13a697d18f2e6b4e6b0c49def06). So the correct adapter has to be included. Not sure whether the readme is specific for latest Laravel versions, I leave that up to you ;)

Have a great day and thanks for this one 🙇