### PR TITLE
Add note for reconnecting in queued jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ App::make('Foo')->bar();
 
 For more information on how to use the `Github\Client` class we are calling behind the scenes here, check out the docs at https://github.com/KnpLabs/php-github-api/tree/v3.0.0/doc, and the manager class at https://github.com/GrahamCampbell/Laravel-Manager#usage.
 
+## Note for Usage in Queued Jobs
+
+While using the package in queued jobs or long-running processes, remember to request for a fresh connection as the previous cached connection's authentication may have expired.
+
+```php
+use GrahamCampbell\GitHub\Facades\GitHub;
+
+Github::reconnect()->issues()->show('GrahamCampbell', 'Laravel-GitHub', 2);
+
+// or for a specific connection:
+Github::reconnect('alternative')->issues()->show('GrahamCampbell', 'Laravel-GitHub', 2);
+```
+
 ##### Further Information
 
 There are other classes in this package that are not documented here. This is because they are not intended for public use and are used internally by this package.


### PR DESCRIPTION
Thanks for the awesome package!

This PR adds a cautionary note to remember to reconnect for queued jobs or long running processes. I faced this issue in one of my apps and I thought a mention in the readme might be good. Other services in Laravel such as database, etc. automatically reconnect so I feel it may not be intuitive for Laravel users to do this.

For reference, here's the exception thrown without the `reconnect` call:

'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires {"exception":"[object] (Github\\Exception\\RuntimeException(code: 401): 'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires at /var/www/website/releases/20210301-173228/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php:117)