### PR TITLE
Remove `$` so the copy feature of the Github UI works

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ Laravel GitHub requires [PHP](https://php.net) 7.2-8.1. This particular version 
 To get the latest version, simply require the project using [Composer](https://getcomposer.org). You will need to install any packages that "provide" `psr/http-client-implementation` and `psr/http-factory-implementation`. Most users will want:
 
 ```bash
-$ composer require "graham-campbell/github:^10.3" "guzzlehttp/guzzle:^7.2" "http-interop/http-factory-guzzle:^1.0"
+composer require "graham-campbell/github:^10.3" "guzzlehttp/guzzle:^7.2" "http-interop/http-factory-guzzle:^1.0"
 ```
 
 If you'd like to use the private key authenticator, then you will also need to install `lcobucci/jwt`:
 
 ```bash
-$ composer require lcobucci/jwt:^3.4
+composer require lcobucci/jwt:^3.4
 ```
 
 or:
 
 ```bash
-$ composer require lcobucci/jwt:^4.0
+composer require lcobucci/jwt:^4.0
 ```
 
 Once installed, if you are not using automatic package discovery, then you need to register the `GrahamCampbell\GitHub\GitHubServiceProvider` service provider in your `config/app.php`.
@@ -62,7 +62,7 @@ Laravel GitHub requires connection configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
 This will create a `config/github.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
You can see the feature when you hover over code examples it lets you then copy the code. But when the `$` the pasted code will give an error in the terminal.

<img width="824" alt="image" src="https://user-images.githubusercontent.com/365385/148839473-7fafd6e4-7cf3-4736-afb8-5e5ea5710d06.png">
