### PR TITLE
chore(deps): change knplabs/github-api to ^3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "graham-campbell/manager": "^4.7",
         "illuminate/contracts": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "knplabs/github-api": "3.5.*",
+        "knplabs/github-api": "^3.6",
         "symfony/cache": "^4.3 || ^5.0 || ^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
The maintainer has been working on some fixes as I've been working through some calls for GitHub Apps API endpoints. This change is to allow your package to include their changes as they keep happening until there is a breaking change to cause v4.