### PR TITLE
Update config to accept secrets stored in environmental variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,47 @@ There are two config options:
 
 ##### Default Connection Name
 
-This option (`'default'`) is where you may specify which of the connections below you wish to use as your default connection for all work. Of course, you may use many connections at once using the manager class. The default value for this setting is `'main'`.
+This option (`'default'`) is where you may specify which of the connections below you wish to use as your default connection for all work. Of course, you may use many connections at once using the manager class. The default value for this setting is `'main'`.  
+Option can also be set by setting the environmental variable `GITHUB_DEFAULT_CONNECTION`.
 
 ##### GitHub Connections
 
-This option (`'connections'`) is where each of the connections are setup for your application. Example configuration has been included, but you may add as many connections as you would like. Note that the 5 supported authentication methods are: `"application"`, `"jwt"`, `"none"`, `"private"`, and `"token"`.
+This option (`'connections'`) is where each of the connections are setup for your application. Example configuration has been included, but you may add as many connections as you would like. Note that the 5 supported authentication methods are: `"app"`, `"jwt"`, `"none"`, `"private"`, and `"token"`.
 
 ##### HTTP Cache
 
 This option (`'cache'`) is where each of the cache configurations setup for your application. Only the "illuminate" driver is provided out of the box. Example configuration has been included.
 
+### Authentication
+
+Each connection has its own authentication method, which can be configured by using environmental
+variables.
+
+#### `main`/`token`
+
+| Environmental variable | Description  |
+|------------------------|--------------|
+| `GITHUB_TOKEN`         | Github Token |
+
+#### `app`
+
+| Environmental variable     | Description            |
+|----------------------------|------------------------|
+| `GITHUB_APP_CLIENT_ID`     | Application Client ID  |
+| `GITHUB_APP_CLIENT_SECRET` | Application Secret key |
+
+#### `jwt`
+
+| Environmental variable | Description              |
+|------------------------|--------------------------|
+| `GITHUB_JWT_TOKEN`     | Authentication JWT token |
+
+#### `private`
+
+| Environmental variable    | Description                      |
+|---------------------------|----------------------------------|
+| `GITHUB_PRIVATE_APP_ID`   | Application ID                   |
+| `GITHUB_PRIVATE_KEY_PATH` | Path to the application key file |
 
 ## Usage
 

--- a/config/github.php
+++ b/config/github.php
@@ -24,7 +24,7 @@ return [
     |
     */
 
-    'default' => 'main',
+    'default' => env("GITHUB_DEFAULT_CONNECTION", 'main'),
 
     /*
     |--------------------------------------------------------------------------
@@ -42,7 +42,7 @@ return [
 
         'main' => [
             'method'     => 'token',
-            'token'      => 'your-token',
+            'token'      => env("GITHUB_TOKEN"),
             // 'backoff'    => false,
             // 'cache'      => false,
             // 'version'    => 'v3',
@@ -51,8 +51,8 @@ return [
 
         'app' => [
             'method'       => 'application',
-            'clientId'     => 'your-client-id',
-            'clientSecret' => 'your-client-secret',
+            'clientId'     => env("GITHUB_APP_CLIENT_ID"),
+            'clientSecret' => env("GITHUB_APP_CLIENT_SECRET"),
             // 'backoff'      => false,
             // 'cache'        => false,
             // 'version'      => 'v3',
@@ -61,7 +61,7 @@ return [
 
         'jwt' => [
             'method'       => 'jwt',
-            'token'        => 'your-jwt-token',
+            'token'        => env("GITHUB_JWT_TOKEN"),
             // 'backoff'      => false,
             // 'cache'        => false,
             // 'version'      => 'v3',
@@ -70,8 +70,8 @@ return [
 
         'private' => [
             'method'     => 'private',
-            'appId'      => 'your-github-app-id',
-            'keyPath'    => 'your-private-key-path',
+            'appId'      => env("GITHUB_PRIVATE_APP_ID"),
+            'keyPath'    => env("GITHUB_PRIVATE_KEY_PATH"),
             // 'key'        => 'your-private-key-content',
             // 'passphrase' => 'your-private-key-passphrase'
             // 'backoff'    => false,

--- a/config/github.php
+++ b/config/github.php
@@ -24,7 +24,7 @@ return [
     |
     */
 
-    'default' => env("GITHUB_DEFAULT_CONNECTION", 'main'),
+    'default' => env('GITHUB_DEFAULT_CONNECTION', 'main'),
 
     /*
     |--------------------------------------------------------------------------
@@ -34,7 +34,7 @@ return [
     | Here are each of the connections setup for your application. Example
     | configuration has been included, but you may add as many connections as
     | you would like. Note that the 5 supported authentication methods are:
-    | "application", "jwt", "none", "private", and "token".
+    | 'application', 'jwt', 'none', 'private', and 'token'.
     |
     */
 
@@ -42,7 +42,7 @@ return [
 
         'main' => [
             'method'     => 'token',
-            'token'      => env("GITHUB_TOKEN"),
+            'token'      => env('GITHUB_TOKEN'),
             // 'backoff'    => false,
             // 'cache'      => false,
             // 'version'    => 'v3',
@@ -51,8 +51,8 @@ return [
 
         'app' => [
             'method'       => 'application',
-            'clientId'     => env("GITHUB_APP_CLIENT_ID"),
-            'clientSecret' => env("GITHUB_APP_CLIENT_SECRET"),
+            'clientId'     => env('GITHUB_APP_CLIENT_ID'),
+            'clientSecret' => env('GITHUB_APP_CLIENT_SECRET'),
             // 'backoff'      => false,
             // 'cache'        => false,
             // 'version'      => 'v3',
@@ -61,7 +61,7 @@ return [
 
         'jwt' => [
             'method'       => 'jwt',
-            'token'        => env("GITHUB_JWT_TOKEN"),
+            'token'        => env('GITHUB_JWT_TOKEN'),
             // 'backoff'      => false,
             // 'cache'        => false,
             // 'version'      => 'v3',
@@ -70,8 +70,8 @@ return [
 
         'private' => [
             'method'     => 'private',
-            'appId'      => env("GITHUB_PRIVATE_APP_ID"),
-            'keyPath'    => env("GITHUB_PRIVATE_KEY_PATH"),
+            'appId'      => env('GITHUB_PRIVATE_APP_ID'),
+            'keyPath'    => env('GITHUB_PRIVATE_KEY_PATH'),
             // 'key'        => 'your-private-key-content',
             // 'passphrase' => 'your-private-key-passphrase'
             // 'backoff'    => false,
@@ -96,7 +96,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here are each of the cache configurations setup for your application.
-    | Only the "illuminate" driver is provided out of the box. Example
+    | Only the 'illuminate' driver is provided out of the box. Example
     | configuration has been included.
     |
     */


### PR DESCRIPTION
I updated the default `github.php` config so it accepts GitHub credentials that can be stored in environmental variables, so they do not have to be hard-coded in the configuration file.

I also updated the `README.md` accordingly.